### PR TITLE
feat(cli): add --max-tokens and --max-output-kib caps to chat

### DIFF
--- a/cmd/aixgo/cmd/chat.go
+++ b/cmd/aixgo/cmd/chat.go
@@ -43,14 +43,21 @@ var chatSecretPattern = regexp.MustCompile(
 )
 
 var (
-	chatModel     string
-	chatSessionID string
-	chatNoStream  bool
-	chatPrompt    string
-	chatStdin     bool
-	chatOutput    string
-	chatNoHistory bool
+	chatModel        string
+	chatSessionID    string
+	chatNoStream     bool
+	chatPrompt       string
+	chatStdin        bool
+	chatOutput       string
+	chatNoHistory    bool
+	chatMaxTokens    int
+	chatMaxOutputKiB int
 )
+
+// chatDefaultMaxOutputKiB is the default soft byte cap on non-interactive
+// chat output (1 MiB). It bounds the worst-case blast radius for scripts
+// that pipe the response into another tool without breaking typical use.
+const chatDefaultMaxOutputKiB = 1024
 
 // chatCmd represents the chat command for interactive coding assistant.
 var chatCmd = &cobra.Command{
@@ -96,6 +103,8 @@ func init() {
 	chatCmd.Flags().BoolVar(&chatStdin, "stdin", false, "Append piped stdin to the prompt (auto-enabled when stdin is not a TTY)")
 	chatCmd.Flags().StringVarP(&chatOutput, "output", "o", "text", "Output format for non-interactive mode: text, json")
 	chatCmd.Flags().BoolVar(&chatNoHistory, "no-history", false, "Disable loading and saving readline history for this session")
+	chatCmd.Flags().IntVar(&chatMaxTokens, "max-tokens", 0, "Maximum response tokens (0 = provider default)")
+	chatCmd.Flags().IntVar(&chatMaxOutputKiB, "max-output-kib", chatDefaultMaxOutputKiB, "Soft cap on non-interactive output in KiB; oversized responses are truncated")
 
 	_ = chatCmd.RegisterFlagCompletionFunc("model", completeModelNames)
 	_ = chatCmd.RegisterFlagCompletionFunc("session", completeSessionIDs)
@@ -162,6 +171,7 @@ func runChat(cmd *cobra.Command, _ []string) error {
 	coord, err := coordinator.New(coordinator.Config{
 		Model:     chatModel,
 		Streaming: !chatNoStream,
+		MaxTokens: chatMaxTokens,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to initialize coordinator: %w", err)
@@ -483,6 +493,7 @@ func runChatOneShot(ctx context.Context, stdinPiped bool) error {
 	coord, err := coordinator.New(coordinator.Config{
 		Model:     chatModel,
 		Streaming: false,
+		MaxTokens: chatMaxTokens,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to initialize coordinator: %w", err)
@@ -512,10 +523,12 @@ func runChatOneShot(ctx context.Context, stdinPiped bool) error {
 		fmt.Fprintf(os.Stderr, "warning: failed to save session: %v\n", saveErr)
 	}
 
+	content, truncated := truncateForOutput(response.Content, chatMaxOutputKiB)
+
 	switch chatOutput {
 	case "json":
 		out := map[string]any{
-			"content":                      response.Content,
+			"content":                      content,
 			"cost":                         response.Cost,
 			"model":                        chatModel,
 			"session_id":                   sess.ID,
@@ -523,14 +536,36 @@ func runChatOneShot(ctx context.Context, stdinPiped bool) error {
 			"output_tokens":                response.OutputTokens,
 			"finish_reason":                response.FinishReason,
 			"appended_to_existing_session": appendedToExisting,
+			"truncated":                    truncated,
 		}
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
 		return enc.Encode(out)
 	default:
-		fmt.Println(response.Content)
+		fmt.Println(content)
+		if truncated {
+			fmt.Fprintf(os.Stderr, "warning: output truncated to %d KiB (use --max-output-kib to raise the cap)\n", chatMaxOutputKiB)
+		}
 		return nil
 	}
+}
+
+// truncateForOutput applies a soft byte cap to content. If maxKiB is 0 or
+// negative the content is returned unchanged. Truncation is byte-based on
+// a rune boundary so the result is always valid UTF-8.
+func truncateForOutput(content string, maxKiB int) (string, bool) {
+	if maxKiB <= 0 {
+		return content, false
+	}
+	limit := maxKiB * 1024
+	if len(content) <= limit {
+		return content, false
+	}
+	cut := limit
+	for cut > 0 && (content[cut]&0xC0) == 0x80 {
+		cut--
+	}
+	return content[:cut], true
 }
 
 func printHelp() {

--- a/cmd/aixgo/cmd/chat_test.go
+++ b/cmd/aixgo/cmd/chat_test.go
@@ -1,6 +1,10 @@
 package cmd
 
-import "testing"
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
 
 // TestChatSecretPattern locks in the categories chatSecretPattern is required
 // to suppress (positive cases) AND the categories it must NOT suppress
@@ -44,4 +48,60 @@ func TestChatSecretPattern(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestTruncateForOutput covers the soft byte cap applied to non-interactive
+// chat responses. The function must be a no-op when the cap is disabled or
+// the content fits, must truncate oversized content, and must always return
+// valid UTF-8 (never slice in the middle of a multi-byte rune).
+func TestTruncateForOutput(t *testing.T) {
+	t.Run("disabled cap passes through", func(t *testing.T) {
+		in := strings.Repeat("x", 10_000)
+		got, trunc := truncateForOutput(in, 0)
+		if got != in || trunc {
+			t.Errorf("cap=0: got trunc=%v len=%d, want passthrough", trunc, len(got))
+		}
+	})
+
+	t.Run("negative cap passes through", func(t *testing.T) {
+		got, trunc := truncateForOutput("hello", -1)
+		if got != "hello" || trunc {
+			t.Errorf("cap=-1: got trunc=%v content=%q, want passthrough", trunc, got)
+		}
+	})
+
+	t.Run("under cap unchanged", func(t *testing.T) {
+		in := strings.Repeat("x", 500)
+		got, trunc := truncateForOutput(in, 1)
+		if got != in || trunc {
+			t.Errorf("under cap: got trunc=%v len=%d, want unchanged", trunc, len(got))
+		}
+	})
+
+	t.Run("over cap truncated", func(t *testing.T) {
+		in := strings.Repeat("x", 3000)
+		got, trunc := truncateForOutput(in, 1)
+		if !trunc {
+			t.Error("over cap: expected truncated=true")
+		}
+		if len(got) > 1024 {
+			t.Errorf("over cap: got len=%d, want <=1024", len(got))
+		}
+	})
+
+	t.Run("multibyte rune boundary", func(t *testing.T) {
+		// Japanese chars are 3 bytes in UTF-8. Build content that would slice
+		// a rune if truncation used a raw byte cut.
+		in := strings.Repeat("あ", 500) // 1500 bytes
+		got, trunc := truncateForOutput(in, 1)
+		if !trunc {
+			t.Error("expected truncated=true")
+		}
+		if !utf8.ValidString(got) {
+			t.Errorf("truncated output is not valid UTF-8: %q", got)
+		}
+		if len(got) > 1024 {
+			t.Errorf("got len=%d, want <=1024", len(got))
+		}
+	})
 }

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -93,7 +93,7 @@ This catalog contains:
 | **Streaming Output** | ✅ Implemented | Real-time streaming responses | `pkg/assistant/coordinator/streaming.go` |
 | **Model Switching** | ✅ Implemented | Switch models mid-conversation (/model) | `cmd/aixgo/cmd/chat.go` |
 | **Interactive Prompts** | ✅ Implemented | Selection menus and confirmations | `pkg/assistant/prompt/` |
-| **Non-Interactive Mode** | ✅ Implemented | One-shot prompts via `-p`, stdin piping, `--output json` for scripting | `cmd/aixgo/cmd/chat.go` |
+| **Non-Interactive Mode** | ✅ Implemented | One-shot prompts via `-p`, stdin piping, `--output json`, `--max-tokens`, `--max-output-kib` soft cap with truncation | `cmd/aixgo/cmd/chat.go` |
 | **Readline Input** | ✅ Implemented | Arrow-key history recall, line editing, persisted history (`~/.aixgo/chat_history`), tab-completion for slash commands | `cmd/aixgo/cmd/chat.go` |
 
 ### Assistant Tools


### PR DESCRIPTION
Closes #166

  Bounds the denial-of-wallet / denial-of-downstream blast radius of `aixgo chat -p` in scripts and CI pipelines.

  ## Changes
  - `--max-tokens` flag → `coordinator.Config.MaxTokens` (0 = provider default)
  - `--max-output-kib` flag (default 1024) → soft byte cap via new `truncateForOutput` helper
  - JSON output gains `truncated` bool field
  - Text output emits stderr warning on truncation
  - UTF-8 safe: truncation aligns to rune boundary

  ## Test plan
  - [x] `TestTruncateForOutput` — 5 sub-tests (disabled, negative, under, over, multibyte)
  - [x] `go build ./...`, `go vet ./...`, `golangci-lint run` (0 issues)
  - [ ] Manual: `aixgo chat -p "count to 100" --max-tokens 20` → short response
  - [ ] Manual: `aixgo chat -p "write a long essay" --max-output-kib 1 --output json` → `"truncated": true`