### PR TITLE
fix(cli): harden chat cleanup (#164 #165 #167 #168)

### DIFF
--- a/cmd/aixgo/cmd/chat.go
+++ b/cmd/aixgo/cmd/chat.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -24,6 +25,14 @@ import (
 
 // chatSlashCommands is the set of in-session commands used for tab-completion.
 var chatSlashCommands = []string{"/model", "/cost", "/save", "/clear", "/help", "/quit", "/exit"}
+
+// chatUntrustedTagPattern matches any opening or closing <untrusted_input>
+// tag with tolerant spacing and case, so buildOneShotInput can neutralize
+// wrapper-escape attempts from piped payloads. Matches:
+//
+//	</untrusted_input>, </UNTRUSTED_INPUT>, </untrusted_input >,
+//	< / untrusted_input >, <untrusted_input>, <UNTRUSTED_INPUT>, etc.
+var chatUntrustedTagPattern = regexp.MustCompile(`(?i)<\s*/?\s*untrusted_input\s*>`)
 
 // chatSecretPattern matches common secret/token shapes that must never be
 // appended to the readline history file. Keep this conservative: prefer false
@@ -42,6 +51,14 @@ var chatSecretPattern = regexp.MustCompile(
 		`|-----BEGIN [A-Z ]*PRIVATE KEY-----`, // PEM private key block
 )
 
+// Package-level vars are retained ONLY as cobra flag-binding targets
+// (chatCmd.Flags().StringVarP requires an *string). They are NEVER read
+// directly by runChat or downstream helpers — instead, runChat snapshots
+// them once into a chatOptions value at entry, and that value is threaded
+// explicitly through all helpers. This eliminates the confused-deputy risk
+// where, e.g., runSessionResume mutated chatSessionID before re-entering
+// runChat: the snapshot still happens after the mutation, so behavior is
+// preserved while preventing other code from observing the mutated globals.
 var (
 	chatModel        string
 	chatSessionID    string
@@ -53,6 +70,38 @@ var (
 	chatMaxTokens    int
 	chatMaxOutputKiB int
 )
+
+// chatOptions captures the per-invocation chat configuration. A fresh value
+// is built from the cobra flag globals at the start of every runChat call,
+// then passed by value to every downstream helper. No helper reads the
+// package-level chatX vars directly.
+type chatOptions struct {
+	Model        string
+	SessionID    string
+	NoStream     bool
+	Prompt       string
+	Stdin        bool
+	Output       string
+	NoHistory    bool
+	MaxTokens    int
+	MaxOutputKiB int
+}
+
+// snapshotChatOptions builds a chatOptions value from the current cobra
+// flag globals. Called exactly once per runChat invocation.
+func snapshotChatOptions() chatOptions {
+	return chatOptions{
+		Model:        chatModel,
+		SessionID:    chatSessionID,
+		NoStream:     chatNoStream,
+		Prompt:       chatPrompt,
+		Stdin:        chatStdin,
+		Output:       chatOutput,
+		NoHistory:    chatNoHistory,
+		MaxTokens:    chatMaxTokens,
+		MaxOutputKiB: chatMaxOutputKiB,
+	}
+}
 
 // chatDefaultMaxOutputKiB is the default soft byte cap on non-interactive
 // chat output (1 MiB). It bounds the worst-case blast radius for scripts
@@ -117,14 +166,18 @@ func runChat(cmd *cobra.Command, _ []string) error {
 	ctx, cancel := context.WithCancel(cmd.Context())
 	defer cancel()
 
-	if chatOutput != "text" && chatOutput != "json" {
-		return fmt.Errorf("invalid --output %q: must be 'text' or 'json'", chatOutput)
+	// Snapshot flag globals into a per-invocation options value. This is the
+	// ONLY place the chatX globals are read in runChat's downstream flow.
+	opts := snapshotChatOptions()
+
+	if opts.Output != "text" && opts.Output != "json" {
+		return fmt.Errorf("invalid --output %q: must be 'text' or 'json'", opts.Output)
 	}
 
 	// Non-interactive one-shot mode: -p provided OR stdin is piped.
 	stdinPiped := !isTerminal(os.Stdin)
-	if chatPrompt != "" || chatStdin || (stdinPiped && chatPrompt == "") {
-		return runChatOneShot(ctx, stdinPiped)
+	if opts.Prompt != "" || opts.Stdin || (stdinPiped && opts.Prompt == "") {
+		return runChatOneShot(ctx, opts, stdinPiped)
 	}
 
 	// Handle shutdown signals
@@ -144,34 +197,34 @@ func runChat(cmd *cobra.Command, _ []string) error {
 
 	// Initialize or resume session
 	var sess *session.Session
-	if chatSessionID != "" {
-		sess, err = sessionMgr.Get(chatSessionID)
+	if opts.SessionID != "" {
+		sess, err = sessionMgr.Get(opts.SessionID)
 		if err != nil {
-			return fmt.Errorf("failed to resume session %s: %w", chatSessionID, err)
+			return fmt.Errorf("failed to resume session %s: %w", opts.SessionID, err)
 		}
 		fmt.Printf("Resumed session: %s\n", sess.ID)
 	} else {
 		// Prompt for model selection if not specified via flag
-		if chatModel == "" || chatModel == "claude-sonnet-4-6" {
+		if opts.Model == "" || opts.Model == "claude-sonnet-4-6" {
 			selectedModel, err := prompt.SelectModel()
 			if err != nil {
 				return fmt.Errorf("model selection failed: %w", err)
 			}
-			chatModel = selectedModel
+			opts.Model = selectedModel
 		}
 
-		sess, err = sessionMgr.Create(chatModel)
+		sess, err = sessionMgr.Create(opts.Model)
 		if err != nil {
 			return fmt.Errorf("failed to create session: %w", err)
 		}
-		fmt.Printf("New session: %s (model: %s)\n", sess.ID, chatModel)
+		fmt.Printf("New session: %s (model: %s)\n", sess.ID, opts.Model)
 	}
 
 	// Initialize coordinator
 	coord, err := coordinator.New(coordinator.Config{
-		Model:     chatModel,
-		Streaming: !chatNoStream,
-		MaxTokens: chatMaxTokens,
+		Model:     opts.Model,
+		Streaming: !opts.NoStream,
+		MaxTokens: opts.MaxTokens,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to initialize coordinator: %w", err)
@@ -179,11 +232,11 @@ func runChat(cmd *cobra.Command, _ []string) error {
 
 	// Initialize output renderer
 	renderer := output.NewRenderer(output.Config{
-		Streaming: !chatNoStream,
+		Streaming: !opts.NoStream,
 	})
 
 	// Print welcome message
-	printWelcome(chatModel)
+	printWelcome(opts.Model)
 
 	// Initialize readline with history, tab completion, and Ctrl+C handling.
 	line := liner.NewLiner()
@@ -202,16 +255,23 @@ func runChat(cmd *cobra.Command, _ []string) error {
 	})
 
 	historyPath := chatHistoryFilePath()
-	if !chatNoHistory {
-		// #nosec G304 -- historyPath is constructed from os.UserHomeDir() and a fixed
-		// relative path (.aixgo/chat_history); not influenced by untrusted input.
-		if f, err := os.Open(historyPath); err == nil {
+	if !opts.NoHistory {
+		// Use O_NOFOLLOW on Unix (see chat_history_unix.go) to reject history
+		// files that have been replaced with a symlink. On Windows this falls
+		// back to a plain open (see chat_history_windows.go).
+		f, err := openChatHistoryForRead(historyPath)
+		if err == nil {
 			_, _ = line.ReadHistory(f)
 			_ = f.Close()
+		} else if !errors.Is(err, os.ErrNotExist) {
+			// ENOENT is normal (first run). Anything else — most notably
+			// ELOOP from O_NOFOLLOW rejecting a symlinked history file —
+			// is worth surfacing so users notice tampering or perms issues.
+			fmt.Fprintf(os.Stderr, "warning: could not load chat history (%v); continuing without it\n", err)
 		}
 	}
 	defer func() {
-		if !chatNoHistory {
+		if !opts.NoHistory {
 			persistChatHistory(line, historyPath)
 		}
 		_ = line.Close()
@@ -242,7 +302,7 @@ func runChat(cmd *cobra.Command, _ []string) error {
 
 		// Handle in-session commands
 		if strings.HasPrefix(input, "/") {
-			handled, err := handleCommand(ctx, input, sess, sessionMgr, coord)
+			handled, err := handleCommand(ctx, input, sess, sessionMgr, coord, &opts)
 			if err != nil {
 				fmt.Printf("Error: %v\n", err)
 			}
@@ -278,7 +338,7 @@ func runChat(cmd *cobra.Command, _ []string) error {
 			Role:      "assistant",
 			Content:   response.Content,
 			Timestamp: time.Now(),
-			Model:     chatModel,
+			Model:     opts.Model,
 			Cost:      response.Cost,
 		})
 
@@ -297,16 +357,34 @@ func runChat(cmd *cobra.Command, _ []string) error {
 	}
 }
 
+// chatHistorySuppressionNotice prints a one-time stderr notice when a line
+// is dropped from readline history because it matched chatSecretPattern.
+// Declared as a var-of-func so tests can stub it without rewriting
+// appendChatHistorySafe.
+var chatHistorySuppressionNotice = func() {
+	fmt.Fprintln(os.Stderr, "note: suppressed 1 line from history (matched secret pattern); use --no-history to fully disable")
+}
+
+// chatHistorySuppressedOnce ensures the suppression notice is emitted at
+// most once per process invocation. Subsequent suppressions continue
+// silently so the chat loop does not get noisy.
+var chatHistorySuppressedOnce sync.Once
+
 // appendChatHistorySafe appends input to the liner history only when it does
 // not look like a secret (API key, bearer token, JWT, PEM block, etc.). This
 // is a best-effort defense against pasted credentials being written to the
 // on-disk history file. For fully guaranteed suppression, users should run
 // with --no-history.
+//
+// On the FIRST suppression per process, a one-line notice is emitted to
+// stderr via chatHistorySuppressionNotice so users whose legitimate input
+// happened to match the regex understand why up-arrow recall is missing.
 func appendChatHistorySafe(line *liner.State, input string) {
 	if line == nil || input == "" {
 		return
 	}
 	if chatSecretPattern.MatchString(input) {
+		chatHistorySuppressedOnce.Do(chatHistorySuppressionNotice)
 		return
 	}
 	line.AppendHistory(input)
@@ -346,7 +424,12 @@ func persistChatHistory(line *liner.State, path string) {
 	_, _ = line.WriteHistory(f)
 }
 
-func handleCommand(_ context.Context, input string, sess *session.Session, mgr *session.Manager, coord *coordinator.Coordinator) (bool, error) {
+// handleCommand processes in-session slash commands. opts is passed by
+// pointer (unlike runChatOneShot which takes chatOptions by value) because
+// /model needs to mutate opts.Model so that subsequent iterations of the
+// chat loop record the new model on outgoing session.Message values. No
+// mutation of opts leaks back to the package-level chatX globals.
+func handleCommand(_ context.Context, input string, sess *session.Session, mgr *session.Manager, coord *coordinator.Coordinator, opts *chatOptions) (bool, error) {
 	parts := strings.Fields(input)
 	if len(parts) == 0 {
 		return false, nil
@@ -373,7 +456,7 @@ func handleCommand(_ context.Context, input string, sess *session.Session, mgr *
 		if err := coord.SetModel(newModel); err != nil {
 			return true, fmt.Errorf("failed to switch model: %w", err)
 		}
-		chatModel = newModel
+		opts.Model = newModel
 		sess.Model = newModel
 		fmt.Printf("Switched to model: %s\n", newModel)
 		return true, nil
@@ -434,37 +517,67 @@ func isTerminal(f *os.File) bool {
 	return (fi.Mode() & os.ModeCharDevice) != 0
 }
 
-// runChatOneShot executes a single non-interactive chat turn and exits.
-// The prompt is built from --prompt and/or piped stdin, sent to the
-// coordinator as a single user message, and the response is printed to
-// stdout in the requested format (text or json).
-func runChatOneShot(ctx context.Context, stdinPiped bool) error {
-	userInput := chatPrompt
-	if chatStdin || (stdinPiped && userInput == "") {
-		data, err := io.ReadAll(os.Stdin)
-		if err != nil {
-			return fmt.Errorf("read stdin: %w", err)
-		}
-		piped := strings.TrimSpace(string(data))
-		if piped != "" {
+// buildOneShotInput produces the final user message for a non-interactive
+// chat turn from a caller-supplied --prompt flag and already-read piped
+// stdin content. It is pure (does no I/O) so it can be unit-tested without
+// stubbing os.Stdin.
+//
+// Semantics:
+//   - prompt only: return prompt verbatim
+//   - stdin only (stdinPiped && promptFlag == ""): return piped verbatim
+//   - prompt + stdin: wrap piped in <untrusted_input>...</untrusted_input>
+//     delimiters so downstream models can distinguish operator instructions
+//     from potentially untrusted external content (L2 prompt-injection
+//     mitigation). Any literal opening or closing wrapper tag inside the
+//     piped payload — in any case and with any internal whitespace — is
+//     escaped via chatUntrustedTagPattern so it cannot break out of, or
+//     open a confusing nested region inside, the wrapper.
+//   - both empty: return ("", error)
+//
+// The caller is responsible for reading os.Stdin and passing the trimmed
+// result as `piped`, along with whether stdin was actually a pipe.
+func buildOneShotInput(promptFlag, piped string, stdinPiped bool) (string, error) {
+	userInput := promptFlag
+	if stdinPiped || piped != "" {
+		trimmed := strings.TrimSpace(piped)
+		if trimmed != "" {
 			if userInput == "" {
-				// Stdin is the entire prompt (no user-supplied -p); pass through
-				// verbatim as direct user input.
-				userInput = piped
+				userInput = trimmed
 			} else {
-				// L2 defense-in-depth: when piped stdin is appended to a
-				// user-supplied --prompt, wrap it in delimiters so downstream
-				// models can distinguish operator instructions from potentially
-				// untrusted external content (prompt-injection mitigation).
-				// Neutralize any literal closing tag inside the piped content
-				// so it cannot escape the wrapper and re-enter "trusted" scope.
-				safe := strings.ReplaceAll(piped, "</untrusted_input>", "<\\/untrusted_input>")
+				// Escape any wrapper-tag-shaped substring (open or close,
+				// case-insensitive, whitespace-tolerant) by inserting a
+				// backslash after the opening '<'. This neutralizes both
+				// break-out attempts via </untrusted_input> variants and
+				// nested-region confusion via <untrusted_input> variants.
+				safe := chatUntrustedTagPattern.ReplaceAllStringFunc(trimmed, func(m string) string {
+					return "<\\" + m[1:]
+				})
 				userInput = userInput + "\n\n<untrusted_input>\n" + safe + "\n</untrusted_input>"
 			}
 		}
 	}
 	if strings.TrimSpace(userInput) == "" {
-		return fmt.Errorf("no prompt provided (use --prompt or pipe input via stdin)")
+		return "", fmt.Errorf("no prompt provided (use --prompt or pipe input via stdin)")
+	}
+	return userInput, nil
+}
+
+// runChatOneShot executes a single non-interactive chat turn and exits.
+// The prompt is built from --prompt and/or piped stdin, sent to the
+// coordinator as a single user message, and the response is printed to
+// stdout in the requested format (text or json).
+func runChatOneShot(ctx context.Context, opts chatOptions, stdinPiped bool) error {
+	var piped string
+	if opts.Stdin || (stdinPiped && opts.Prompt == "") {
+		data, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			return fmt.Errorf("read stdin: %w", err)
+		}
+		piped = string(data)
+	}
+	userInput, err := buildOneShotInput(opts.Prompt, piped, stdinPiped)
+	if err != nil {
+		return err
 	}
 
 	sessionMgr, err := session.NewManager()
@@ -474,26 +587,26 @@ func runChatOneShot(ctx context.Context, stdinPiped bool) error {
 
 	appendedToExisting := false
 	var sess *session.Session
-	if chatSessionID != "" {
-		sess, err = sessionMgr.Get(chatSessionID)
+	if opts.SessionID != "" {
+		sess, err = sessionMgr.Get(opts.SessionID)
 		if err != nil {
-			return fmt.Errorf("failed to resume session %s: %w", chatSessionID, err)
+			return fmt.Errorf("failed to resume session %s: %w", opts.SessionID, err)
 		}
 		appendedToExisting = true
 		// M3: make the append-to-existing-session behavior explicit so users
 		// are not silently mutating history in one-shot mode.
 		fmt.Fprintf(os.Stderr, "appending to existing session %s\n", sess.ID)
 	} else {
-		sess, err = sessionMgr.Create(chatModel)
+		sess, err = sessionMgr.Create(opts.Model)
 		if err != nil {
 			return fmt.Errorf("failed to create session: %w", err)
 		}
 	}
 
 	coord, err := coordinator.New(coordinator.Config{
-		Model:     chatModel,
+		Model:     opts.Model,
 		Streaming: false,
-		MaxTokens: chatMaxTokens,
+		MaxTokens: opts.MaxTokens,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to initialize coordinator: %w", err)
@@ -514,7 +627,7 @@ func runChatOneShot(ctx context.Context, stdinPiped bool) error {
 		Role:      "assistant",
 		Content:   response.Content,
 		Timestamp: time.Now(),
-		Model:     chatModel,
+		Model:     opts.Model,
 		Cost:      response.Cost,
 	})
 	sess.TotalCost += response.Cost
@@ -523,14 +636,14 @@ func runChatOneShot(ctx context.Context, stdinPiped bool) error {
 		fmt.Fprintf(os.Stderr, "warning: failed to save session: %v\n", saveErr)
 	}
 
-	content, truncated := truncateForOutput(response.Content, chatMaxOutputKiB)
+	content, truncated := truncateForOutput(response.Content, opts.MaxOutputKiB)
 
-	switch chatOutput {
+	switch opts.Output {
 	case "json":
 		out := map[string]any{
 			"content":                      content,
 			"cost":                         response.Cost,
-			"model":                        chatModel,
+			"model":                        opts.Model,
 			"session_id":                   sess.ID,
 			"input_tokens":                 response.InputTokens,
 			"output_tokens":                response.OutputTokens,
@@ -544,7 +657,7 @@ func runChatOneShot(ctx context.Context, stdinPiped bool) error {
 	default:
 		fmt.Println(content)
 		if truncated {
-			fmt.Fprintf(os.Stderr, "warning: output truncated to %d KiB (use --max-output-kib to raise the cap)\n", chatMaxOutputKiB)
+			fmt.Fprintf(os.Stderr, "warning: output truncated to %d KiB (use --max-output-kib to raise the cap)\n", opts.MaxOutputKiB)
 		}
 		return nil
 	}

--- a/cmd/aixgo/cmd/chat_history_unix.go
+++ b/cmd/aixgo/cmd/chat_history_unix.go
@@ -1,0 +1,24 @@
+//go:build !windows
+
+package cmd
+
+import (
+	"os"
+	"syscall"
+)
+
+// openChatHistoryForRead opens the chat history file read-only with
+// O_NOFOLLOW so that a symlink replacement (e.g. an attacker pointing
+// ~/.aixgo/chat_history at another file on the system) is rejected with
+// ELOOP rather than silently followed. This is defense-in-depth against
+// local write access to the user's dotfiles directory; it does not
+// protect against an attacker who can already overwrite files as the
+// user, but it prevents the readline layer from being tricked into
+// slurping arbitrary file contents into its in-memory history buffer
+// (which would then be rewritten back to chat_history on shutdown).
+//
+// #nosec G304 -- path is constructed from os.UserHomeDir() and a fixed
+// relative path (.aixgo/chat_history); not influenced by untrusted input.
+func openChatHistoryForRead(path string) (*os.File, error) {
+	return os.OpenFile(path, os.O_RDONLY|syscall.O_NOFOLLOW, 0)
+}

--- a/cmd/aixgo/cmd/chat_history_unix_test.go
+++ b/cmd/aixgo/cmd/chat_history_unix_test.go
@@ -1,0 +1,68 @@
+//go:build !windows
+
+package cmd
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+// TestOpenChatHistoryForRead_RejectsSymlink verifies the O_NOFOLLOW
+// mitigation in openChatHistoryForRead: a history path that has been
+// replaced with a symlink to another file must be rejected with ELOOP
+// rather than silently followed (which would let the readline layer
+// slurp arbitrary file contents into its history buffer).
+func TestOpenChatHistoryForRead_RejectsSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target")
+	if err := os.WriteFile(target, []byte("sensitive\n"), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+
+	link := filepath.Join(dir, "chat_history")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	f, err := openChatHistoryForRead(link)
+	if err == nil {
+		_ = f.Close()
+		t.Fatal("openChatHistoryForRead followed a symlink; expected ELOOP rejection")
+	}
+	if !errors.Is(err, syscall.ELOOP) {
+		t.Errorf("expected ELOOP, got %v", err)
+	}
+}
+
+// TestOpenChatHistoryForRead_RegularFile verifies the happy path still
+// works for a non-symlink history file.
+func TestOpenChatHistoryForRead_RegularFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "chat_history")
+	if err := os.WriteFile(path, []byte("hello\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	f, err := openChatHistoryForRead(path)
+	if err != nil {
+		t.Fatalf("openChatHistoryForRead: %v", err)
+	}
+	_ = f.Close()
+}
+
+// TestOpenChatHistoryForRead_Missing verifies ENOENT is returned (and
+// therefore classified by the caller as "normal first run") for a
+// nonexistent history path.
+func TestOpenChatHistoryForRead_Missing(t *testing.T) {
+	dir := t.TempDir()
+	f, err := openChatHistoryForRead(filepath.Join(dir, "does_not_exist"))
+	if err == nil {
+		_ = f.Close()
+		t.Fatal("expected error for missing file")
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("expected os.ErrNotExist, got %v", err)
+	}
+}

--- a/cmd/aixgo/cmd/chat_history_windows.go
+++ b/cmd/aixgo/cmd/chat_history_windows.go
@@ -1,0 +1,17 @@
+//go:build windows
+
+package cmd
+
+import "os"
+
+// openChatHistoryForRead opens the chat history file read-only. Windows
+// does not expose an O_NOFOLLOW equivalent via the os package, so this
+// falls back to a plain open. The file is still scoped to %USERPROFILE%
+// and written with 0o600 on Unix; Windows users do not benefit from the
+// symlink-rejection mitigation but are no worse off than before.
+//
+// #nosec G304 -- path is constructed from os.UserHomeDir() and a fixed
+// relative path (.aixgo/chat_history); not influenced by untrusted input.
+func openChatHistoryForRead(path string) (*os.File, error) {
+	return os.Open(path)
+}

--- a/cmd/aixgo/cmd/chat_test.go
+++ b/cmd/aixgo/cmd/chat_test.go
@@ -2,8 +2,11 @@ package cmd
 
 import (
 	"strings"
+	"sync"
 	"testing"
 	"unicode/utf8"
+
+	"github.com/peterh/liner"
 )
 
 // TestChatSecretPattern locks in the categories chatSecretPattern is required
@@ -104,4 +107,189 @@ func TestTruncateForOutput(t *testing.T) {
 			t.Errorf("got len=%d, want <=1024", len(got))
 		}
 	})
+}
+
+// TestBuildOneShotInput locks in the contract for assembling the final
+// user message from --prompt and piped stdin, including the L2
+// <untrusted_input> delimiter wrap and the closing-tag escape that
+// prevents injected payloads from escaping the wrapper.
+func TestBuildOneShotInput(t *testing.T) {
+	tests := []struct {
+		name       string
+		prompt     string
+		piped      string
+		stdinPiped bool
+		want       string
+		wantErr    bool
+	}{
+		{
+			name:   "prompt only",
+			prompt: "explain this error",
+			want:   "explain this error",
+		},
+		{
+			name:       "stdin only",
+			piped:      "go build ./... failed\n",
+			stdinPiped: true,
+			want:       "go build ./... failed",
+		},
+		{
+			name:       "prompt plus stdin wraps in delimiters",
+			prompt:     "review this diff",
+			piped:      "diff --git a/foo b/foo\n+bar\n",
+			stdinPiped: true,
+			want:       "review this diff\n\n<untrusted_input>\ndiff --git a/foo b/foo\n+bar\n</untrusted_input>",
+		},
+		{
+			name:       "prompt plus stdin escapes literal closing tag",
+			prompt:     "summarize",
+			piped:      "before </untrusted_input> after",
+			stdinPiped: true,
+			want:       "summarize\n\n<untrusted_input>\nbefore <\\/untrusted_input> after\n</untrusted_input>",
+		},
+		{
+			name:       "prompt plus stdin escapes uppercase closing tag",
+			prompt:     "summarize",
+			piped:      "before </UNTRUSTED_INPUT> after",
+			stdinPiped: true,
+			want:       "summarize\n\n<untrusted_input>\nbefore <\\/UNTRUSTED_INPUT> after\n</untrusted_input>",
+		},
+		{
+			name:       "prompt plus stdin escapes closing tag with whitespace",
+			prompt:     "summarize",
+			piped:      "before </ untrusted_input > after",
+			stdinPiped: true,
+			want:       "summarize\n\n<untrusted_input>\nbefore <\\/ untrusted_input > after\n</untrusted_input>",
+		},
+		{
+			name:       "prompt plus stdin escapes nested opening tag",
+			prompt:     "summarize",
+			piped:      "before <untrusted_input> after",
+			stdinPiped: true,
+			want:       "summarize\n\n<untrusted_input>\nbefore <\\untrusted_input> after\n</untrusted_input>",
+		},
+		{
+			name:    "both empty returns error",
+			wantErr: true,
+		},
+		{
+			name:       "whitespace-only piped with no prompt returns error",
+			piped:      "   \n\t  ",
+			stdinPiped: true,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := buildOneShotInput(tt.prompt, tt.piped, tt.stdinPiped)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("buildOneShotInput() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if got != tt.want {
+				t.Errorf("buildOneShotInput() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestAppendChatHistorySafe_SuppressionNotice verifies that a secret match
+// causes the line to be dropped AND emits the one-time stderr notice
+// exactly once per process invocation. The notice function is stubbed via
+// the var-of-func hook and the sync.Once gate is reset per subtest.
+func TestAppendChatHistorySafe_SuppressionNotice(t *testing.T) {
+	// Preserve and restore the notice hook so this test does not leak
+	// into other tests that exercise appendChatHistorySafe. The sync.Once
+	// itself cannot be saved by value (vet: copies lock value), so each
+	// subtest assigns a fresh zero value directly.
+	origNotice := chatHistorySuppressionNotice
+	t.Cleanup(func() {
+		chatHistorySuppressionNotice = origNotice
+		chatHistorySuppressedOnce = sync.Once{}
+	})
+
+	reset := func() *int {
+		calls := 0
+		chatHistorySuppressionNotice = func() { calls++ }
+		chatHistorySuppressedOnce = sync.Once{}
+		return &calls
+	}
+
+	line := liner.NewLiner()
+	t.Cleanup(func() { _ = line.Close() })
+
+	t.Run("secret match suppresses and notifies once", func(t *testing.T) {
+		calls := reset()
+		appendChatHistorySafe(line, "sk-abcdefghijklmnopqrstuvwxyz0123")
+		appendChatHistorySafe(line, "sk-zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz")
+		appendChatHistorySafe(line, "ghp_abcdefghijklmnopqrstuvwxyz")
+		if *calls != 1 {
+			t.Errorf("notice called %d times, want exactly 1 (one-time per process)", *calls)
+		}
+	})
+
+	t.Run("non-secret input does not notify", func(t *testing.T) {
+		calls := reset()
+		appendChatHistorySafe(line, "hello world")
+		appendChatHistorySafe(line, "/help")
+		if *calls != 0 {
+			t.Errorf("notice called %d times, want 0 (nothing suppressed)", *calls)
+		}
+	})
+
+	t.Run("empty input is a no-op", func(t *testing.T) {
+		calls := reset()
+		appendChatHistorySafe(line, "")
+		if *calls != 0 {
+			t.Errorf("notice called %d times on empty input, want 0", *calls)
+		}
+	})
+}
+
+// TestSnapshotChatOptions verifies that snapshotting captures all current
+// flag-global values and that subsequent mutations do not leak back
+// through the snapshot (value semantics check).
+func TestSnapshotChatOptions(t *testing.T) {
+	// Save and restore all flag globals.
+	origs := []interface{}{chatModel, chatSessionID, chatNoStream, chatPrompt, chatStdin, chatOutput, chatNoHistory, chatMaxTokens, chatMaxOutputKiB}
+	t.Cleanup(func() {
+		chatModel = origs[0].(string)
+		chatSessionID = origs[1].(string)
+		chatNoStream = origs[2].(bool)
+		chatPrompt = origs[3].(string)
+		chatStdin = origs[4].(bool)
+		chatOutput = origs[5].(string)
+		chatNoHistory = origs[6].(bool)
+		chatMaxTokens = origs[7].(int)
+		chatMaxOutputKiB = origs[8].(int)
+	})
+
+	chatModel = "gpt-4o"
+	chatSessionID = "sess-123"
+	chatNoStream = true
+	chatPrompt = "p"
+	chatStdin = true
+	chatOutput = "json"
+	chatNoHistory = true
+	chatMaxTokens = 1000
+	chatMaxOutputKiB = 256
+
+	opts := snapshotChatOptions()
+
+	// Mutate globals after snapshot — opts must not observe the change.
+	chatModel = "mutated"
+	chatSessionID = "mutated"
+
+	if opts.Model != "gpt-4o" || opts.SessionID != "sess-123" {
+		t.Errorf("snapshot leaked post-snapshot mutation: Model=%q SessionID=%q", opts.Model, opts.SessionID)
+	}
+	if !opts.NoStream || opts.Prompt != "p" || !opts.Stdin || opts.Output != "json" || !opts.NoHistory {
+		t.Errorf("snapshot did not capture all fields: %+v", opts)
+	}
+	if opts.MaxTokens != 1000 || opts.MaxOutputKiB != 256 {
+		t.Errorf("snapshot int fields wrong: MaxTokens=%d MaxOutputKiB=%d", opts.MaxTokens, opts.MaxOutputKiB)
+	}
 }


### PR DESCRIPTION
Closes #164, #165, #167, #168

  Single scoped PR for four CLI follow-ups from the security review.

  ## Changes
  - **#164** Per-invocation `chatOptions` snapshot; `/model` mutates `opts.Model` not global
  - **#165** `O_NOFOLLOW` on Unix history read (build-tagged), non-ENOENT errors surfaced
  - **#167** One-time stderr notice on first secret-pattern suppression
  - **#168** Pure `buildOneShotInput` helper with case/whitespace-insensitive tag escape

  ## Follow-ups filed
  - #171 Windows reparse-point hardening
  - #172 /model no-leak test

  ## Test plan
  - [x] `go build ./...`
  - [x] `go vet ./...`
  - [x] `GOOS=windows go build ./cmd/aixgo/...`
  - [x] `golangci-lint run` — 0 issues
  - [x] `go test -count=1 -race ./cmd/aixgo/...`
  - [ ] Manual Unix: replace `~/.aixgo/chat_history` with symlink, verify warning