### PR TITLE
feat(cli): add aixgo doctor environment diagnostics

### DIFF
--- a/cmd/aixgo/cmd/doctor.go
+++ b/cmd/aixgo/cmd/doctor.go
@@ -1,0 +1,397 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aixgo-dev/aixgo"
+	"github.com/aixgo-dev/aixgo/pkg/llm/provider"
+	"github.com/spf13/cobra"
+)
+
+// errDoctorChecksFailed is returned by runDoctor when one or more checks
+// failed. Cobra's root.Execute() converts any non-nil error into exit 1,
+// so returning this sentinel gives us the same exit code as os.Exit(1)
+// without bypassing deferred cleanup. It is paired with SilenceErrors /
+// SilenceUsage on doctorCmd so cobra does not print a redundant error
+// line or usage dump after we have already rendered the report.
+var errDoctorChecksFailed = errors.New("doctor: one or more checks failed")
+
+// doctorMinGoMajor and doctorMinGoMinor define the minimum Go version the
+// project supports. Keep in sync with go.mod.
+const (
+	doctorMinGoMajor = 1
+	doctorMinGoMinor = 26
+)
+
+// doctorDialTimeout bounds the per-server MCP reachability probe so a slow
+// or blackholed address cannot hang the doctor run.
+const doctorDialTimeout = 2 * time.Second
+
+// doctorStatus is the per-check outcome. warn does not fail the overall run.
+type doctorStatus string
+
+const (
+	statusOK   doctorStatus = "ok"
+	statusWarn doctorStatus = "warn"
+	statusFail doctorStatus = "fail"
+)
+
+// doctorCheck is the result of a single diagnostic check.
+type doctorCheck struct {
+	Name    string       `json:"name"`
+	Status  doctorStatus `json:"status"`
+	Message string       `json:"message"`
+}
+
+// doctorReport is the JSON envelope emitted in --output json mode.
+type doctorReport struct {
+	OK     bool          `json:"ok"`
+	Checks []doctorCheck `json:"checks"`
+}
+
+var (
+	doctorConfigFile string
+	doctorOutput     string
+)
+
+var doctorCmd = &cobra.Command{
+	Use:   "doctor",
+	Short: "Run environment diagnostics and readiness checks",
+	// SilenceUsage: we already render a full report, so cobra's usage dump
+	// on error would be noise. SilenceErrors: root.Execute prints the error
+	// itself; our sentinel is lowercased to match idiomatic cobra output.
+	SilenceErrors: true,
+	SilenceUsage:  true,
+	Long: `Run a fast environment readiness check and report the status of each area.
+
+aixgo doctor is intended as the first command to run after install and as
+the thing to paste into bug reports. It verifies:
+
+  - Go runtime version meets the minimum required
+  - At least one LLM provider API key is configured
+  - ~/.aixgo state directory exists with restrictive permissions
+  - Optional: a YAML config file parses cleanly (--config)
+  - Optional: every MCP server in the config is reachable (--config)
+
+Exit codes:
+  0  all checks pass (warnings are OK)
+  1  any check failed
+
+Examples:
+  aixgo doctor
+  aixgo doctor --output json
+  aixgo doctor --config config/agents.yaml
+  aixgo doctor --config config/agents.yaml --output json`,
+	RunE: runDoctor,
+}
+
+func init() {
+	rootCmd.AddCommand(doctorCmd)
+
+	doctorCmd.Flags().StringVarP(&doctorConfigFile, "config", "c", getEnv("CONFIG_FILE", ""), "Optional YAML config to validate and probe")
+	doctorCmd.Flags().StringVarP(&doctorOutput, "output", "o", "text", "Output format: text, json")
+
+	_ = doctorCmd.RegisterFlagCompletionFunc("config", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return []string{"yaml", "yml"}, cobra.ShellCompDirectiveFilterFileExt
+	})
+	_ = doctorCmd.RegisterFlagCompletionFunc("output", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return []string{"text", "json"}, cobra.ShellCompDirectiveNoFileComp
+	})
+}
+
+func runDoctor(cmd *cobra.Command, _ []string) error {
+	if doctorOutput != "text" && doctorOutput != "json" {
+		return fmt.Errorf("invalid --output %q: must be 'text' or 'json'", doctorOutput)
+	}
+
+	ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
+	defer cancel()
+
+	checks := runDoctorChecks(ctx, doctorConfigFile)
+	report := doctorReport{
+		OK:     doctorReportOK(checks),
+		Checks: checks,
+	}
+
+	switch doctorOutput {
+	case "json":
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(report); err != nil {
+			return fmt.Errorf("encode report: %w", err)
+		}
+	default:
+		printDoctorText(report)
+	}
+
+	if !report.OK {
+		// Returning a sentinel gives cobra's root.Execute the exit-1 it
+		// needs while still running our deferred cancel(). SilenceErrors
+		// on doctorCmd prevents cobra from double-printing, but the outer
+		// Execute in root.go will still emit this message to stderr,
+		// which is fine alongside the rendered report.
+		return errDoctorChecksFailed
+	}
+	return nil
+}
+
+// runDoctorChecks executes every diagnostic check and returns the results in
+// a deterministic order. It is a pure helper (modulo file/env reads) so it
+// can be exercised from tests without shelling out.
+func runDoctorChecks(ctx context.Context, configPath string) []doctorCheck {
+	var checks []doctorCheck
+
+	checks = append(checks, checkGoVersion(runtime.Version()))
+	checks = append(checks, checkProviderKeys(provider.GetAvailableProviderNames()))
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		checks = append(checks, doctorCheck{
+			Name:    "state directory",
+			Status:  statusWarn,
+			Message: fmt.Sprintf("cannot resolve home directory: %v", err),
+		})
+	} else {
+		checks = append(checks, checkStateDir(filepath.Join(home, ".aixgo")))
+	}
+
+	if configPath != "" {
+		cfg, cfgCheck := checkConfigFile(configPath)
+		checks = append(checks, cfgCheck)
+		if cfg != nil {
+			checks = append(checks, checkMCPReachability(ctx, cfg.MCPServers)...)
+		}
+	}
+
+	return checks
+}
+
+// checkGoVersion parses a Go version string like "go1.26.3" and reports
+// whether it meets the minimum supported version.
+func checkGoVersion(v string) doctorCheck {
+	major, minor, ok := parseGoVersion(v)
+	if !ok {
+		return doctorCheck{
+			Name:    "go runtime",
+			Status:  statusWarn,
+			Message: fmt.Sprintf("unrecognized Go version %q", v),
+		}
+	}
+	if major < doctorMinGoMajor || (major == doctorMinGoMajor && minor < doctorMinGoMinor) {
+		return doctorCheck{
+			Name:   "go runtime",
+			Status: statusFail,
+			Message: fmt.Sprintf(
+				"Go %d.%d < required %d.%d",
+				major, minor, doctorMinGoMajor, doctorMinGoMinor,
+			),
+		}
+	}
+	return doctorCheck{
+		Name:    "go runtime",
+		Status:  statusOK,
+		Message: fmt.Sprintf("Go %d.%d", major, minor),
+	}
+}
+
+// parseGoVersion extracts major and minor version numbers from a Go version
+// string of the form "go1.26.3" or "go1.26". Returns ok=false when the
+// prefix or digits cannot be parsed.
+func parseGoVersion(v string) (major, minor int, ok bool) {
+	v = strings.TrimPrefix(v, "go")
+	parts := strings.SplitN(v, ".", 3)
+	if len(parts) < 2 {
+		return 0, 0, false
+	}
+	maj, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, 0, false
+	}
+	min, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, 0, false
+	}
+	return maj, min, true
+}
+
+// checkProviderKeys reports which LLM providers have API keys configured.
+// Zero providers is a fail (the CLI cannot do any LLM work).
+func checkProviderKeys(available []string) doctorCheck {
+	if len(available) == 0 {
+		return doctorCheck{
+			Name:   "provider keys",
+			Status: statusFail,
+			Message: "no provider API keys detected (set one of " +
+				"ANTHROPIC_API_KEY, OPENAI_API_KEY, GOOGLE_API_KEY, " +
+				"XAI_API_KEY, or AWS credentials for Bedrock)",
+		}
+	}
+	return doctorCheck{
+		Name:    "provider keys",
+		Status:  statusOK,
+		Message: fmt.Sprintf("configured: %s", strings.Join(available, ", ")),
+	}
+}
+
+// checkStateDir verifies the ~/.aixgo directory exists with mode 0o700.
+// Missing is a warn (it will be created on first use); wider perms is a warn.
+func checkStateDir(dir string) doctorCheck {
+	info, err := os.Stat(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return doctorCheck{
+				Name:    "state directory",
+				Status:  statusWarn,
+				Message: fmt.Sprintf("%s does not exist (will be created on first use)", dir),
+			}
+		}
+		return doctorCheck{
+			Name:    "state directory",
+			Status:  statusFail,
+			Message: fmt.Sprintf("stat %s: %v", dir, err),
+		}
+	}
+	if !info.IsDir() {
+		return doctorCheck{
+			Name:    "state directory",
+			Status:  statusFail,
+			Message: fmt.Sprintf("%s is not a directory", dir),
+		}
+	}
+	mode := info.Mode().Perm()
+	if mode&0o077 != 0 {
+		return doctorCheck{
+			Name:    "state directory",
+			Status:  statusWarn,
+			Message: fmt.Sprintf("%s has permissive mode %04o (expected 0700)", dir, mode),
+		}
+	}
+	return doctorCheck{
+		Name:    "state directory",
+		Status:  statusOK,
+		Message: fmt.Sprintf("%s mode %04o", dir, mode),
+	}
+}
+
+// checkConfigFile loads and parses the YAML config via the shared secure
+// loader, returning the parsed config on success so downstream checks can
+// use it. Parse failure is a fail.
+func checkConfigFile(path string) (*aixgo.Config, doctorCheck) {
+	loader := aixgo.NewConfigLoader(&aixgo.OSFileReader{})
+	cfg, err := loader.LoadConfig(path)
+	if err != nil {
+		return nil, doctorCheck{
+			Name:    "config file",
+			Status:  statusFail,
+			Message: fmt.Sprintf("%s: %v", path, err),
+		}
+	}
+	return cfg, doctorCheck{
+		Name:    "config file",
+		Status:  statusOK,
+		Message: fmt.Sprintf("%s parsed (%d agents, %d mcp servers)", path, len(cfg.Agents), len(cfg.MCPServers)),
+	}
+}
+
+// checkMCPReachability probes every gRPC-transport MCP server with a short
+// TCP dial. Local-transport entries are reported as skipped. Each server
+// produces one check.
+func checkMCPReachability(ctx context.Context, servers []aixgo.MCPServerDef) []doctorCheck {
+	if len(servers) == 0 {
+		return nil
+	}
+	out := make([]doctorCheck, 0, len(servers))
+	for _, s := range servers {
+		name := fmt.Sprintf("mcp: %s", s.Name)
+		if s.Transport != "grpc" {
+			out = append(out, doctorCheck{
+				Name:    name,
+				Status:  statusOK,
+				Message: fmt.Sprintf("transport=%s (no reachability probe)", s.Transport),
+			})
+			continue
+		}
+		if s.Address == "" {
+			out = append(out, doctorCheck{
+				Name:    name,
+				Status:  statusFail,
+				Message: "grpc transport requires address",
+			})
+			continue
+		}
+		dialCtx, cancel := context.WithTimeout(ctx, doctorDialTimeout)
+		var dialer net.Dialer
+		conn, err := dialer.DialContext(dialCtx, "tcp", s.Address)
+		cancel()
+		if err != nil {
+			// Unreachable MCP servers are warnings, not failures: many
+			// aixgo commands (chat, models, version) do not need MCP at
+			// all, so a dead dev-time MCP endpoint must not exit-1 the
+			// whole doctor run. Misconfiguration (missing address) is
+			// still a fail above.
+			out = append(out, doctorCheck{
+				Name:    name,
+				Status:  statusWarn,
+				Message: fmt.Sprintf("%s: %v", s.Address, err),
+			})
+			continue
+		}
+		_ = conn.Close()
+		out = append(out, doctorCheck{
+			Name:    name,
+			Status:  statusOK,
+			Message: fmt.Sprintf("%s reachable", s.Address),
+		})
+	}
+	return out
+}
+
+// doctorReportOK returns true when no check has statusFail. Warnings are
+// informational and do not fail the overall run.
+func doctorReportOK(checks []doctorCheck) bool {
+	for _, c := range checks {
+		if c.Status == statusFail {
+			return false
+		}
+	}
+	return true
+}
+
+// printDoctorText emits the human-friendly text rendering.
+func printDoctorText(r doctorReport) {
+	fmt.Println()
+	fmt.Println("aixgo doctor")
+	fmt.Println("════════════")
+	for _, c := range r.Checks {
+		fmt.Printf("  %s  %-22s  %s\n", statusGlyph(c.Status), c.Name, c.Message)
+	}
+	fmt.Println()
+	if r.OK {
+		fmt.Println("all checks passed")
+	} else {
+		fmt.Println("one or more checks failed")
+	}
+}
+
+func statusGlyph(s doctorStatus) string {
+	switch s {
+	case statusOK:
+		return "[ok]  "
+	case statusWarn:
+		return "[warn]"
+	case statusFail:
+		return "[fail]"
+	default:
+		return "[?]   "
+	}
+}

--- a/cmd/aixgo/cmd/doctor_test.go
+++ b/cmd/aixgo/cmd/doctor_test.go
@@ -1,0 +1,309 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/aixgo-dev/aixgo"
+)
+
+func TestParseGoVersion(t *testing.T) {
+	tests := []struct {
+		in        string
+		maj, min  int
+		ok        bool
+	}{
+		{"go1.26.3", 1, 26, true},
+		{"go1.26", 1, 26, true},
+		{"go1.21.0", 1, 21, true},
+		{"1.26.3", 1, 26, true},
+		{"", 0, 0, false},
+		{"devel", 0, 0, false},
+		{"go1.x", 0, 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			maj, min, ok := parseGoVersion(tt.in)
+			if ok != tt.ok || maj != tt.maj || min != tt.min {
+				t.Errorf("parseGoVersion(%q) = (%d,%d,%v), want (%d,%d,%v)",
+					tt.in, maj, min, ok, tt.maj, tt.min, tt.ok)
+			}
+		})
+	}
+}
+
+func TestCheckGoVersion(t *testing.T) {
+	tests := []struct {
+		name   string
+		in     string
+		status doctorStatus
+	}{
+		{"current", "go1.26.0", statusOK},
+		{"future", "go1.30.1", statusOK},
+		{"newer major", "go2.0.0", statusOK},
+		{"too old", "go1.25.0", statusFail},
+		{"way too old", "go1.20.0", statusFail},
+		{"unparseable", "devel", statusWarn},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := checkGoVersion(tt.in)
+			if got.Status != tt.status {
+				t.Errorf("status = %v, want %v (msg=%q)", got.Status, tt.status, got.Message)
+			}
+		})
+	}
+}
+
+func TestCheckProviderKeys(t *testing.T) {
+	t.Run("none configured is fail", func(t *testing.T) {
+		got := checkProviderKeys(nil)
+		if got.Status != statusFail {
+			t.Errorf("got %v, want fail", got.Status)
+		}
+	})
+	t.Run("one configured is ok", func(t *testing.T) {
+		got := checkProviderKeys([]string{"anthropic"})
+		if got.Status != statusOK {
+			t.Errorf("got %v, want ok", got.Status)
+		}
+		if !strings.Contains(got.Message, "anthropic") {
+			t.Errorf("message %q missing provider name", got.Message)
+		}
+	})
+	t.Run("multiple configured is ok", func(t *testing.T) {
+		got := checkProviderKeys([]string{"anthropic", "openai", "bedrock"})
+		if got.Status != statusOK {
+			t.Errorf("got %v, want ok", got.Status)
+		}
+	})
+}
+
+func TestCheckStateDir(t *testing.T) {
+	t.Run("missing is warn", func(t *testing.T) {
+		got := checkStateDir(filepath.Join(t.TempDir(), "does-not-exist"))
+		if got.Status != statusWarn {
+			t.Errorf("got %v, want warn", got.Status)
+		}
+	})
+
+	t.Run("0700 is ok", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "aixgo")
+		if err := os.Mkdir(dir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		got := checkStateDir(dir)
+		if got.Status != statusOK {
+			t.Errorf("got %v, want ok (msg=%q)", got.Status, got.Message)
+		}
+	})
+
+	t.Run("0755 is warn", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "aixgo")
+		if err := os.Mkdir(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		got := checkStateDir(dir)
+		if got.Status != statusWarn {
+			t.Errorf("got %v, want warn", got.Status)
+		}
+	})
+
+	t.Run("regular file is fail", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "not-a-dir")
+		if err := os.WriteFile(path, []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		got := checkStateDir(path)
+		if got.Status != statusFail {
+			t.Errorf("got %v, want fail", got.Status)
+		}
+	})
+}
+
+func TestCheckConfigFile(t *testing.T) {
+	t.Run("missing is fail", func(t *testing.T) {
+		_, got := checkConfigFile(filepath.Join(t.TempDir(), "absent.yaml"))
+		if got.Status != statusFail {
+			t.Errorf("got %v, want fail", got.Status)
+		}
+	})
+
+	t.Run("valid yaml is ok", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "ok.yaml")
+		body := "agents:\n  - name: a\n    role: logger\n"
+		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		cfg, got := checkConfigFile(path)
+		if got.Status != statusOK {
+			t.Errorf("got %v (msg=%q), want ok", got.Status, got.Message)
+		}
+		if cfg == nil {
+			t.Fatal("expected non-nil config")
+		}
+		if len(cfg.Agents) != 1 {
+			t.Errorf("agents = %d, want 1", len(cfg.Agents))
+		}
+	})
+
+	t.Run("invalid yaml is fail", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "bad.yaml")
+		if err := os.WriteFile(path, []byte("agents: [\n  - broken"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		cfg, got := checkConfigFile(path)
+		if got.Status != statusFail {
+			t.Errorf("got %v, want fail", got.Status)
+		}
+		if cfg != nil {
+			t.Error("expected nil config on parse failure")
+		}
+	})
+}
+
+func TestCheckMCPReachability(t *testing.T) {
+	t.Run("empty is nil", func(t *testing.T) {
+		got := checkMCPReachability(context.Background(), nil)
+		if got != nil {
+			t.Errorf("got %d checks, want nil", len(got))
+		}
+	})
+
+	t.Run("local transport skipped", func(t *testing.T) {
+		got := checkMCPReachability(context.Background(), []aixgo.MCPServerDef{
+			{Name: "local", Transport: "local"},
+		})
+		if len(got) != 1 || got[0].Status != statusOK {
+			t.Errorf("got %+v, want single ok", got)
+		}
+	})
+
+	t.Run("grpc without address is fail", func(t *testing.T) {
+		got := checkMCPReachability(context.Background(), []aixgo.MCPServerDef{
+			{Name: "bad", Transport: "grpc"},
+		})
+		if len(got) != 1 || got[0].Status != statusFail {
+			t.Errorf("got %+v, want single fail", got)
+		}
+	})
+
+	t.Run("grpc unreachable is warn", func(t *testing.T) {
+		// Reserve a loopback port then close it so the address is
+		// guaranteed to refuse connections on every OS (including CI
+		// runners where 127.0.0.1:1 may behave unpredictably).
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatal(err)
+		}
+		addr := ln.Addr().String()
+		if err := ln.Close(); err != nil {
+			t.Fatal(err)
+		}
+		got := checkMCPReachability(context.Background(), []aixgo.MCPServerDef{
+			{Name: "dead", Transport: "grpc", Address: addr},
+		})
+		if len(got) != 1 || got[0].Status != statusWarn {
+			t.Errorf("got %+v, want single warn", got)
+		}
+	})
+
+	t.Run("grpc reachable is ok", func(t *testing.T) {
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = ln.Close() }()
+		addr := ln.Addr().String()
+		got := checkMCPReachability(context.Background(), []aixgo.MCPServerDef{
+			{Name: "live", Transport: "grpc", Address: addr},
+		})
+		if len(got) != 1 || got[0].Status != statusOK {
+			t.Errorf("got %+v, want single ok", got)
+		}
+	})
+}
+
+func TestStatusGlyph(t *testing.T) {
+	tests := []struct {
+		in   doctorStatus
+		want string
+	}{
+		{statusOK, "[ok]  "},
+		{statusWarn, "[warn]"},
+		{statusFail, "[fail]"},
+		{doctorStatus("unknown"), "[?]   "},
+	}
+	for _, tt := range tests {
+		if got := statusGlyph(tt.in); got != tt.want {
+			t.Errorf("statusGlyph(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+// TestDoctorReportJSONEnvelope locks the JSON envelope shape so downstream
+// tooling (bug-report paste, CI parsers) can rely on {ok, checks[]} with
+// stable field names and statuses.
+func TestDoctorReportJSONEnvelope(t *testing.T) {
+	r := doctorReport{
+		OK: false,
+		Checks: []doctorCheck{
+			{Name: "go runtime", Status: statusOK, Message: "Go 1.26"},
+			{Name: "provider keys", Status: statusFail, Message: "none"},
+		},
+	}
+	b, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var round struct {
+		OK     bool `json:"ok"`
+		Checks []struct {
+			Name    string `json:"name"`
+			Status  string `json:"status"`
+			Message string `json:"message"`
+		} `json:"checks"`
+	}
+	if err := json.Unmarshal(b, &round); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if round.OK != false {
+		t.Errorf("ok = %v, want false", round.OK)
+	}
+	if len(round.Checks) != 2 {
+		t.Fatalf("checks = %d, want 2", len(round.Checks))
+	}
+	if round.Checks[0].Status != "ok" || round.Checks[1].Status != "fail" {
+		t.Errorf("statuses = %q/%q, want ok/fail",
+			round.Checks[0].Status, round.Checks[1].Status)
+	}
+	if round.Checks[0].Name != "go runtime" {
+		t.Errorf("name = %q, want 'go runtime'", round.Checks[0].Name)
+	}
+}
+
+func TestDoctorReportOK(t *testing.T) {
+	tests := []struct {
+		name   string
+		checks []doctorCheck
+		ok     bool
+	}{
+		{"empty", nil, true},
+		{"all ok", []doctorCheck{{Status: statusOK}, {Status: statusOK}}, true},
+		{"warn only", []doctorCheck{{Status: statusOK}, {Status: statusWarn}}, true},
+		{"one fail", []doctorCheck{{Status: statusOK}, {Status: statusFail}}, false},
+		{"only fail", []doctorCheck{{Status: statusFail}}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := doctorReportOK(tt.checks); got != tt.ok {
+				t.Errorf("got %v, want %v", got, tt.ok)
+			}
+		})
+	}
+}

--- a/cmd/aixgo/cmd/root.go
+++ b/cmd/aixgo/cmd/root.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -35,7 +36,11 @@ Use "aixgo [command] --help" for more information about a command.`,
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
+		// doctor renders its own report and returns a sentinel purely to
+		// drive the exit code; don't double-print its message.
+		if !errors.Is(err, errDoctorChecksFailed) {
+			fmt.Fprintln(os.Stderr, err)
+		}
 		os.Exit(1)
 	}
 }

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -82,6 +82,7 @@ This catalog contains:
 | **session Command** | ✅ Implemented | Session management (list, resume, delete) | `cmd/aixgo/cmd/session.go` |
 | **models Command** | ✅ Implemented | List available LLM models with pricing | `cmd/aixgo/cmd/models.go` |
 | **Shell Completion** | ✅ Implemented | bash/zsh/fish/powershell completion with dynamic model/session/config suggestions | `cmd/aixgo/cmd/completion.go` |
+| **doctor Command** | ✅ Implemented | Environment diagnostics: Go version, provider keys, state dir perms, config validation, MCP reachability; text/JSON output | `cmd/aixgo/cmd/doctor.go` |
 
 ### Interactive Chat Assistant
 


### PR DESCRIPTION
Closes #176

  New `aixgo doctor` subcommand — fast environment readiness check, intended as the first command to run after
  install and the thing to paste into bug reports.

  ## Checks
  - Go runtime version (fails below 1.26)
  - Provider API keys (fails if none)
  - `~/.aixgo/` existence + 0700 perms (warns on missing/permissive)
  - Optional `--config`: YAML parse via shared secure loader
  - Optional MCP reachability: 2s TCP dial per grpc server (warn on unreachable, fail on missing address)

  ## Output
  `--output text|json` with stable `{ok, checks[]}` envelope.

  ## Review hardening (applied inline)
  - Sentinel error instead of `os.Exit(1)` so deferred cancel() runs
  - MCP dial failures as warn (chat/models/version don't need MCP)
  - Hermetic reserve-and-close for the unreachable-port test

  ## Follow-ups
  - #177 checkConfigFile return shape
  - #178 extensible check registry
  - #179 move MCP probe into pkg/mcp
  - #180 align --config validation with run command

  ## Test plan
  - [x] `go build ./...`
  - [x] `go vet ./...`
  - [x] `GOOS=windows go build ./cmd/aixgo/...`
  - [x] `golangci-lint run` — 0 issues
  - [x] `go test -count=1 -race ./cmd/aixgo/...`
  - [x] Manual: `aixgo doctor` → exit 0 with all checks
  - [ ] Manual: `aixgo doctor --output json | jq`
  - [ ] Manual: `aixgo doctor --config config/agents.yaml`