### PR TITLE
test(security): regression coverage for #131 + SSRF + file-perm fixes

### DIFF
--- a/pkg/assistant/session/manager_test.go
+++ b/pkg/assistant/session/manager_test.go
@@ -420,3 +420,52 @@ func TestManager_Validation(t *testing.T) {
 		}
 	})
 }
+
+// TestLoadSession_RejectsTraversalID is the defence-in-depth companion to
+// TestManager_Validation. Get/Delete/Save already gate their inputs, but
+// loadSession is unexported and historically reachable from internal
+// callers; the A5 guard on the direct entry point must reject malformed
+// ids regardless of how the call site was constructed.
+func TestLoadSession_RejectsTraversalID(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "aixgo-session-loadsession")
+	if err != nil {
+		t.Fatalf("mktemp: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	mgr := &Manager{sessionsDir: tmpDir}
+
+	// Create one real session so the valid-id path has something to load.
+	created, err := mgr.Create("gpt-4o")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		id      string
+		wantErr error
+	}{
+		{"rejects empty", "", ErrInvalidSessionID},
+		{"rejects short", "abc", ErrInvalidSessionID},
+		{"rejects traversal", "../../etc/pa", ErrInvalidSessionID},
+		{"rejects uppercase hex", "ABCDEF012345", ErrInvalidSessionID},
+		{"rejects null byte", "abc\x00def0123", ErrInvalidSessionID},
+		{"accepts valid", created.ID, nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := mgr.loadSession(tt.id)
+			if tt.wantErr == nil {
+				if err != nil {
+					t.Errorf("loadSession(%q) err = %v, want nil", tt.id, err)
+				}
+				return
+			}
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("loadSession(%q) err = %v, want ErrInvalidSessionID", tt.id, err)
+			}
+		})
+	}
+}

--- a/pkg/security/extractor_test.go
+++ b/pkg/security/extractor_test.go
@@ -5,7 +5,10 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestDisabledAuthExtractor(t *testing.T) {
@@ -588,5 +591,158 @@ func TestHeaderRoleInjection(t *testing.T) {
 	}
 	if !hasValidRole {
 		t.Error("Expected at least one valid role after sanitization")
+	}
+}
+
+// TestLoadAPIKeysFromFile_PathTraversal guards the #131 defence-in-depth
+// cleaning added to loadAPIKeysFromFile. The function is called with an
+// operator-supplied config path, so the goal is to ensure neither a
+// traversal sequence, nor a symlink-adjacent path, nor a world-readable
+// fixture sneaks past the gates.
+func TestLoadAPIKeysFromFile_PathTraversal(t *testing.T) {
+	dir := t.TempDir()
+
+	validPath := filepath.Join(dir, "keys.json")
+	if err := os.WriteFile(validPath, []byte(`{"alice":"secret1"}`), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	worldReadablePath := filepath.Join(dir, "keys-wide.json")
+	if err := os.WriteFile(worldReadablePath, []byte(`{"bob":"secret2"}`), 0o644); err != nil {
+		t.Fatalf("write world-readable fixture: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		path    string
+		wantErr bool
+		// errSubstr is matched against err.Error() when wantErr is true.
+		// Empty means "any error is fine".
+		errSubstr string
+	}{
+		{
+			name:      "empty path rejected",
+			path:      "",
+			wantErr:   true,
+			errSubstr: "cannot be empty",
+		},
+		{
+			name:      "parent traversal rejected",
+			path:      "../etc/shadow",
+			wantErr:   true,
+			errSubstr: "traversal",
+		},
+		{
+			// Construct the path manually so filepath.Join does not strip
+			// the ".." before it reaches loadAPIKeysFromFile.
+			name:      "raw dot-dot survives clean rejected",
+			path:      "../../../../../../etc/shadow",
+			wantErr:   true,
+			errSubstr: "traversal",
+		},
+		{
+			name:      "nonexistent file surfaces stat error",
+			path:      filepath.Join(dir, "does-not-exist"),
+			wantErr:   true,
+			errSubstr: "stat",
+		},
+		{
+			name:      "world-readable fixture rejected",
+			path:      worldReadablePath,
+			wantErr:   true,
+			errSubstr: "world-readable",
+		},
+		{
+			name:    "valid JSON keys loaded",
+			path:    validPath,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := loadAPIKeysFromFile(tt.path)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("loadAPIKeysFromFile(%q) error = %v, wantErr %v", tt.path, err, tt.wantErr)
+			}
+			if tt.wantErr {
+				if tt.errSubstr != "" && !strings.Contains(err.Error(), tt.errSubstr) {
+					t.Errorf("err = %q, want substring %q", err.Error(), tt.errSubstr)
+				}
+				return
+			}
+			if len(got) == 0 {
+				t.Errorf("expected at least one key, got %d", len(got))
+			}
+		})
+	}
+}
+
+// TestGoogleJWKClient_Configuration asserts the SSRF hardening applied to
+// the Google JWK fetch path (gosec G107 #118). The client itself is a
+// package-private sync.Once singleton, so this test verifies the post-once
+// state: allowlist hosts, scheme restriction, block flags, timeout, and
+// redirect denial. A full httptest round-trip is deferred to an integration
+// test because the endpoints are compile-time constants.
+func TestGoogleJWKClient_Configuration(t *testing.T) {
+	client, validator := getGoogleJWKClient()
+	if client == nil || validator == nil {
+		t.Fatal("getGoogleJWKClient returned nil client or validator")
+	}
+
+	t.Run("timeout is 10 seconds", func(t *testing.T) {
+		if client.Timeout != 10*time.Second {
+			t.Errorf("client.Timeout = %v, want 10s", client.Timeout)
+		}
+	})
+
+	t.Run("redirect is denied", func(t *testing.T) {
+		if client.CheckRedirect == nil {
+			t.Fatal("client.CheckRedirect is nil, want a deny-redirect function")
+		}
+		if err := client.CheckRedirect(nil, nil); err == nil {
+			t.Error("CheckRedirect returned nil, want non-nil to deny redirect")
+		}
+	})
+
+	t.Run("validator accepts www.gstatic.com https", func(t *testing.T) {
+		if err := validator.ValidateURL("https://www.gstatic.com/iap/verify/public_key-jwk"); err != nil {
+			t.Errorf("ValidateURL(gstatic) error = %v, want nil", err)
+		}
+	})
+
+	t.Run("validator accepts www.googleapis.com https", func(t *testing.T) {
+		if err := validator.ValidateURL("https://www.googleapis.com/oauth2/v3/certs"); err != nil {
+			t.Errorf("ValidateURL(googleapis) error = %v, want nil", err)
+		}
+	})
+
+	t.Run("validator rejects non-allowlist host", func(t *testing.T) {
+		if err := validator.ValidateURL("https://evil.example.com/keys"); err == nil {
+			t.Error("ValidateURL(evil.example.com) = nil, want allowlist rejection")
+		}
+	})
+
+	t.Run("validator rejects http scheme", func(t *testing.T) {
+		if err := validator.ValidateURL("http://www.gstatic.com/iap/verify/public_key-jwk"); err == nil {
+			t.Error("ValidateURL(http) = nil, want scheme rejection")
+		}
+	})
+
+	t.Run("validator rejects loopback", func(t *testing.T) {
+		if err := validator.ValidateURL("https://127.0.0.1/keys"); err == nil {
+			t.Error("ValidateURL(loopback) = nil, want block (AllowLocalhost=false)")
+		}
+	})
+}
+
+// TestErrJWKEndpointBlocked verifies the sentinel exists and has the
+// expected message prefix so operators can distinguish SSRF blocks from
+// transport errors when reading logs.
+func TestErrJWKEndpointBlocked(t *testing.T) {
+	if ErrJWKEndpointBlocked == nil {
+		t.Fatal("ErrJWKEndpointBlocked is nil")
+	}
+	if !strings.Contains(ErrJWKEndpointBlocked.Error(), "ssrf") {
+		t.Errorf("ErrJWKEndpointBlocked.Error() = %q, want substring 'ssrf'", ErrJWKEndpointBlocked.Error())
 	}
 }

--- a/pkg/security/validation_test.go
+++ b/pkg/security/validation_test.go
@@ -1,6 +1,8 @@
 package security
 
 import (
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
@@ -1273,4 +1275,102 @@ func TestValidateDeploymentInputs(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestResolveTLSCertPath guards the #131 TLS CA path-traversal fixes in
+// internal/runtime/distributed.go (buildDialOptions, buildServerOptions) and
+// pkg/mcp/transport_grpc.go (client + server CAFile loads). All four call
+// sites route through ResolveTLSCertPath, so exhaustive coverage here is
+// simultaneously coverage for A2 and A3 in the release-gate checklist.
+func TestResolveTLSCertPath(t *testing.T) {
+	certDir := t.TempDir()
+
+	// Materialise a "real" cert so the absolute-inside-allowlist case has a
+	// tangible path to resolve against (the helper does not stat, but it
+	// gives the test a realistic fixture for future coverage).
+	realCert := filepath.Join(certDir, "ca.pem")
+	if err := os.WriteFile(realCert, []byte("dummy"), 0o600); err != nil {
+		t.Fatalf("fixture cert write: %v", err)
+	}
+
+	t.Setenv("AIXGO_TLS_CERT_DIR", certDir)
+
+	tests := []struct {
+		name    string
+		in      string
+		want    string // expected resolved path (ignored if wantErr)
+		wantErr bool
+	}{
+		{
+			name:    "empty path rejected",
+			in:      "",
+			wantErr: true,
+		},
+		{
+			name: "relative path inside allowlist accepted",
+			in:   "ca.pem",
+			want: realCert,
+		},
+		{
+			name: "absolute path inside allowlist accepted",
+			in:   realCert,
+			want: realCert,
+		},
+		{
+			name:    "traversal via relative parent rejected",
+			in:      "../etc/shadow",
+			wantErr: true,
+		},
+		{
+			name:    "traversal inside allowlist root rejected",
+			in:      "ca/../../../etc/shadow",
+			wantErr: true,
+		},
+		{
+			name:    "absolute path outside allowlist rejected",
+			in:      "/etc/shadow",
+			wantErr: true,
+		},
+		{
+			name:    "absolute traversal segment rejected",
+			in:      filepath.Join(certDir, "..", "escape.pem"),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ResolveTLSCertPath(tt.in)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ResolveTLSCertPath(%q) error = %v, wantErr %v", tt.in, err, tt.wantErr)
+			}
+			if tt.wantErr {
+				if err != nil && strings.Contains(err.Error(), certDir) && !strings.Contains(tt.name, "absolute traversal") {
+					// The helper contract says the error must not leak the
+					// allowlist root. The "absolute traversal segment" case is
+					// exempt because the caller's own path already contains
+					// certDir verbatim.
+					t.Errorf("error message leaked allowlist root: %q", err.Error())
+				}
+				return
+			}
+			if got != tt.want {
+				t.Errorf("ResolveTLSCertPath(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+
+	t.Run("fallback to DefaultTLSCertDir when env unset", func(t *testing.T) {
+		t.Setenv("AIXGO_TLS_CERT_DIR", "")
+		// Absolute path inside /etc/aixgo/certs (fictional, not created) must
+		// still be accepted lexically; filesystem presence is not a
+		// precondition of ResolveTLSCertPath.
+		got, err := ResolveTLSCertPath("/etc/aixgo/certs/server.pem")
+		if err != nil {
+			t.Fatalf("ResolveTLSCertPath() error = %v, want nil", err)
+		}
+		if got != "/etc/aixgo/certs/server.pem" {
+			t.Errorf("ResolveTLSCertPath() = %q, want /etc/aixgo/certs/server.pem", got)
+		}
+	})
 }

--- a/pkg/tools/file/read_test.go
+++ b/pkg/tools/file/read_test.go
@@ -34,12 +34,26 @@ func TestValidatePath(t *testing.T) {
 		t.Fatalf("write inside: %v", err)
 	}
 
-	// Symlink that points outside the allowlist.
+	// Symlink that points outside every allowlist entry. We need a target
+	// that (a) exists on both linux and darwin runners, (b) is NOT inside
+	// cwd, $HOME, /usr/local, /etc, /tmp, /var/folders, or $TMPDIR.
+	//
+	// /etc/hosts won't work because /etc is explicitly on the allowlist
+	// (even though it looks "system-y"). /bin/sh is a reliable choice:
+	// it exists on every Unix and /bin is not an allowlist root.
+	// On linux with usrmerge /bin is a symlink to /usr/bin, which still
+	// resolves outside the allowlist (only /usr/local is allowed).
+	evilTarget := "/bin/sh"
+	if _, statErr := os.Lstat(evilTarget); statErr != nil {
+		evilTarget = ""
+	}
 	evil := filepath.Join(tmpDir, "evil.link")
-	if err := os.Symlink("/etc/hosts", evil); err != nil {
-		// /etc/hosts exists on darwin and linux CI; skip the symlink case if
-		// the runtime cannot create a symlink (e.g. restricted filesystems).
-		t.Logf("symlink skipped: %v", err)
+	if evilTarget != "" {
+		if err := os.Symlink(evilTarget, evil); err != nil {
+			t.Logf("symlink skipped: %v", err)
+			evil = ""
+		}
+	} else {
 		evil = ""
 	}
 

--- a/pkg/tools/file/read_test.go
+++ b/pkg/tools/file/read_test.go
@@ -1,0 +1,167 @@
+package file
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestValidatePath covers the #131 hardening of pkg/tools/file/read.go. The
+// contract is:
+//  1. Empty paths and null bytes are rejected.
+//  2. The absolute, cleaned path must fall inside a non-empty allowlist
+//     (cwd, $HOME, /usr/local, /etc, /tmp, /var/folders, $TMPDIR).
+//  3. If the path already exists, symlinks are resolved and the real target
+//     must also live inside the allowlist (symlink-escape defence).
+func TestValidatePath(t *testing.T) {
+	// Anchor to an allowlisted tempdir so ValidatePath() accepts us.
+	tmpDir := t.TempDir()
+	prevWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(prevWD) })
+
+	// Materialise a real file inside the allowlist so relative paths resolve.
+	inside := filepath.Join(tmpDir, "inside.txt")
+	if err := os.WriteFile(inside, []byte("ok"), 0o600); err != nil {
+		t.Fatalf("write inside: %v", err)
+	}
+
+	// Symlink that points outside the allowlist.
+	evil := filepath.Join(tmpDir, "evil.link")
+	if err := os.Symlink("/etc/hosts", evil); err != nil {
+		// /etc/hosts exists on darwin and linux CI; skip the symlink case if
+		// the runtime cannot create a symlink (e.g. restricted filesystems).
+		t.Logf("symlink skipped: %v", err)
+		evil = ""
+	}
+
+	tests := []struct {
+		name    string
+		path    string
+		skip    bool
+		wantErr bool
+	}{
+		{name: "empty rejected", path: "", wantErr: true},
+		{name: "null byte rejected", path: "a\x00b", wantErr: true},
+		{name: "relative inside cwd accepted", path: "inside.txt", wantErr: false},
+		{name: "absolute inside tmp accepted", path: inside, wantErr: false},
+		{
+			name: "absolute outside allowlist rejected",
+			// /root is outside every allowlist entry on macOS and most linux.
+			path:    "/root/.ssh/id_rsa",
+			wantErr: true,
+			skip:    runtime.GOOS == "windows",
+		},
+		{
+			name:    "symlink escape rejected",
+			path:    evil,
+			wantErr: true,
+			skip:    evil == "",
+		},
+		{
+			name:    "parent-traversal-then-inside still resolves to inside",
+			path:    filepath.Join(tmpDir, "sub", "..", "inside.txt"),
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.skip {
+				t.Skip("not applicable on this platform")
+			}
+			err := ValidatePath(tt.path)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidatePath(%q) err = %v, wantErr %v", tt.path, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestWriteFileHandler_Permissions guards the B fix (gosec G306 #120 and
+// G301 #119). writeFileHandler must create parent directories with 0o750
+// and write files with 0o600, regardless of umask.
+func TestWriteFileHandler_Permissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX mode bits not meaningful on windows")
+	}
+
+	tmpDir := t.TempDir()
+
+	// Target lives inside a nested subdirectory that writeFileHandler will
+	// create via MkdirAll — that's what we want to assert perms on.
+	nested := filepath.Join(tmpDir, "nested", "deeper")
+	target := filepath.Join(nested, "agent-output.txt")
+
+	// The handler calls ValidatePath, so we must chdir into an allowlist
+	// root. tmpDir (inside os.TempDir()) is already covered.
+	prevWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(prevWD) })
+
+	_, err = writeFileHandler(context.Background(), map[string]any{
+		"path":    target,
+		"content": "super secret tool output",
+	})
+	if err != nil {
+		t.Fatalf("writeFileHandler: %v", err)
+	}
+
+	// Verify the directory was created with mode <=0o750.
+	dirInfo, err := os.Stat(nested)
+	if err != nil {
+		t.Fatalf("stat dir: %v", err)
+	}
+	dirMode := dirInfo.Mode().Perm()
+	if dirMode&^0o750 != 0 {
+		t.Errorf("dir mode = %04o, want <=0o750 (G301)", dirMode)
+	}
+
+	// Verify the file was written with mode <=0o600.
+	fileInfo, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("stat file: %v", err)
+	}
+	fileMode := fileInfo.Mode().Perm()
+	if fileMode&^0o600 != 0 {
+		t.Errorf("file mode = %04o, want <=0o600 (G306)", fileMode)
+	}
+}
+
+// TestWriteFileHandler_RejectsTraversal ensures the write path inherits the
+// ValidatePath guard so an agent cannot coerce writes outside the allowlist.
+func TestWriteFileHandler_RejectsTraversal(t *testing.T) {
+	tmpDir := t.TempDir()
+	prevWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(prevWD) })
+
+	_, err = writeFileHandler(context.Background(), map[string]any{
+		"path":    "/root/.ssh/authorized_keys",
+		"content": "attacker-key",
+	})
+	if err == nil {
+		t.Fatal("writeFileHandler accepted /root path, want rejection")
+	}
+	if !strings.Contains(err.Error(), "outside allowed") && !strings.Contains(err.Error(), "path") {
+		t.Errorf("err = %q, want an allowlist-rejection message", err.Error())
+	}
+}


### PR DESCRIPTION
  Closes the v0.6.0 test-coverage gap flagged in the test-engineer audit:

  - validation_test.go: TestResolveTLSCertPath (A2+A3). Single test covers the shared helper behind all four #131 TLS CA call sites in internal/runtime/distributed.go and pkg/mcp/transport_grpc.go.
  - extractor_test.go: TestLoadAPIKeysFromFile_PathTraversal (A1) plus TestGoogleJWKClient_Configuration and TestErrJWKEndpointBlocked covering the SSRF-hardened Google JWK fetch path (F / gosec G107).
  - manager_test.go: TestLoadSession_RejectsTraversalID (A5) — direct unit on loadSession defence-in-depth guard.
  - read_test.go: new file covering ValidatePath, writeFileHandler directory+file permission bits (B / gosec G301+G306), and traversal rejection for writes (A4).

  All suites green: pkg/security/..., pkg/assistant/session/...,
  pkg/tools/file/... with -short.