### PR TITLE
chore(gitignore): ignore 4 more example binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,10 @@ examples/session-react/session-react
 examples/session-basic/session-basic
 examples/resilient-aggregation/resilient-aggregation
 examples/personal-assistant/personal-assistant
+examples/cost-optimization/cost-optimization
+examples/multi-phase-workflow/multi-phase-workflow
+examples/pydantic-style-validation/pydantic-style-validation
+examples/validation-patterns/validation-patterns
 
 # Legacy binary names (root level)
 /aggregator-workflow


### PR DESCRIPTION
Adds the four example binaries that were leaking into `git status` to the existing per-example ignore list in `.gitignore`:

- `examples/cost-optimization/cost-optimization`
- `examples/multi-phase-workflow/multi-phase-workflow`
- `examples/pydantic-style-validation/pydantic-style-validation`
- `examples/validation-patterns/validation-patterns`

`go build` in each example dir drops a binary named after the package directory. These four weren't in the list, so they kept showing up untracked.

No code changes.