### PR TITLE
chore(docs): remove manual version-bump points

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,8 @@
 # CLAUDE.md - AI Assistant Project Guide
 
-**Version**: 0.6.0
 **Last Updated**: 2026-04-21
 **Target**: AI assistants (Claude Code, GitHub Copilot, Cursor, etc.)
+**Current release**: see [GitHub Releases](https://github.com/aixgo-dev/aixgo/releases/latest) (canonical version is the git tag)
 
 Quick reference for AI assistants working with Aixgo - a production-grade AI agent framework for Go.
 
@@ -50,7 +50,7 @@ Aixgo is a **production-grade AI agent framework for Go** enabling secure, scala
 
 ### Current Status
 
-- **Version**: 0.6.0
+- **Current release**: see [GitHub Releases](https://github.com/aixgo-dev/aixgo/releases/latest) — the git tag is the single source of truth
 - **Maturity**: Production-ready for core features
 - **Go Version**: 1.26+
 - **License**: MIT

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,7 +1,7 @@
 # Aixgo Features Reference
 
-**Version**: 0.6.0
 **Last Updated**: 2026-03-08
+**Current release**: see [GitHub Releases](https://github.com/aixgo-dev/aixgo/releases/latest) — canonical version is the git tag; feature-introduction versions (`v0.3.0+` etc.) below are historical markers
 
 ---
 


### PR DESCRIPTION
Makes the git tag the single source of truth for Aixgo's version.

## Problem

CLAUDE.md and docs/FEATURES.md each carried hardcoded `**Version**: 0.x.0` strings that drifted from the actual git tag line (docs said 0.6.0 while tags were on v0.7.x). Three places had to be bumped on every release.

## Fix

Remove the three drift-prone version strings; replace with pointers to [GitHub Releases](https://github.com/aixgo-dev/aixgo/releases/latest). The git tag is now canonical.

## Untouched

- Feature-introduction markers in FEATURES.md like `(v0.3.0+)` — these are historical annotations, not drift.
- `## Version History` changelog table in FEATURES.md — additive, not drift.
- `**Last Updated**` lines — documentation timestamp, independent of releases.

## Net result

**Zero manual bump points** when cutting a release. Just `git tag vX.Y.Z` and goreleaser does the rest.