### PR TITLE
fix(ci): PowerShell variable-reference parse error in Windows verify

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,7 +129,7 @@ jobs:
           if (-not $expectedLine) { throw "no checksum entry for $archive in checksums.txt" }
           $expected = ($expectedLine -split '\s+')[0].ToLower()
           $actual = (Get-FileHash -Algorithm SHA256 $archive).Hash.ToLower()
-          if ($expected -ne $actual) { throw "checksum mismatch for $archive: expected $expected, got $actual" }
+          if ($expected -ne $actual) { throw "checksum mismatch for ${archive}: expected ${expected}, got ${actual}" }
           Write-Host "Checksum verified for $archive"
 
           Expand-Archive -Path $archive -DestinationPath .


### PR DESCRIPTION
## Context

The v0.7.3 release workflow run ([24694251960](https://github.com/aixgo-dev/aixgo/actions/runs/24694251960)) failed on the `Verify windows-latest` job with:

```
ParserError: Variable reference is not valid. ':' was not followed by a valid
variable name character. Consider using ${} to delimit the name.
```

The release itself succeeded — goreleaser published all 13 assets (tarballs, zips, SBOMs, checksums) for v0.7.3. The Windows post-release checksum-verify step broke on a PowerShell syntax issue.

## Root cause

Line 132 of `.github/workflows/release.yml`:

```powershell
throw "checksum mismatch for $archive: expected $expected, got $actual"
```

PowerShell parses `$archive:` as scoped-variable syntax (the same form as `$env:PATH`), and fails because `archive:` isn't a real scope.

## Fix

Wrap the interpolated variables in `${}` to terminate them explicitly:

```powershell
throw "checksum mismatch for ${archive}: expected ${expected}, got ${actual}"
```

One-line change. No other interpolations in the step have the same shape (none are immediately followed by a `:` or other variable-name character, so no other fixes needed).

## Verification plan

- [ ] Future release tag runs the verify step cleanly on Windows.
- [ ] Unix + macOS verify remain unaffected (they use a different shell block).