### PR TITLE
chore(ci): drop stale web/** paths-ignore after web extraction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,12 +3,8 @@ name: CI
 on:
   push:
     branches: [ main, develop ]
-    paths-ignore:
-      - 'web/**'
   pull_request:
     branches: [ main, develop ]
-    paths-ignore:
-      - 'web/**'
 
 env:
   # Minimum Go patch release — matches the `toolchain` directive in go.mod


### PR DESCRIPTION
## Summary
After #207 extracted `web/` to its own repository, the CI workflow still had a `paths-ignore: 'web/**'` filter on both push and pull_request triggers. With the directory gone, those rules never match anything — pure dead config. Removed.

## Context: CodeQL
Triggered by reviewing the [CodeQL config status page](https://github.com/aixgo-dev/aixgo/security/code-scanning/tools/CodeQL/status/configurations/automatic/93f379e61ba95136892f3ceb8d1d217e7a8185a549572efde2ae6db8825eaba2). On the GitHub side, no action is required:

- `code-scanning/default-setup` API now reports `languages: ["actions", "go"]` (no JS/TS) — auto-updated 2026-05-03 right after the web/ extraction.
- 0 open CodeQL alerts.

The only stale references to `web/` anywhere in `.github/` were the two `paths-ignore` entries in `ci.yml` cleaned up in this PR.

## Test plan
- [ ] CI runs on this PR (proves the trigger still fires after removing the empty `paths-ignore` blocks)