### PR TITLE
Read the Go version from go.mod everywhere in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,6 @@ on:
   pull_request:
     branches: [ main, develop ]
 
-env:
-  # Minimum Go patch release — matches the `toolchain` directive in go.mod
-  # and picks up stdlib CVE fixes that our govulncheck CI guard will flag.
-  GO_VERSION: '1.26.5'
-
 permissions:
   contents: read
   security-events: write
@@ -26,7 +21,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: 'go.mod'
 
     - name: golangci-lint
       uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
@@ -37,9 +32,6 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go-version: ['1.26.5']
     steps:
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -47,7 +39,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
-        go-version: ${{ matrix.go-version }}
+        go-version-file: 'go.mod'
         cache: true
         cache-dependency-path: go.sum
 
@@ -68,7 +60,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: 'go.mod'
 
     - name: Build
       run: |
@@ -125,7 +117,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: 'go.mod'
         cache: true
         cache-dependency-path: go.sum
 

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/aixgo-dev/aixgo
 
 go 1.26
 
+// The single Go pin: CI reads this file via go-version-file, so bumping
+// the patch here bumps it everywhere.
 toolchain go1.26.5
 
 require (


### PR DESCRIPTION
The exact Go patch was pinned in three places that had to move together: go.mod's `toolchain` directive, ci.yml's `GO_VERSION` env, and a one-entry test matrix. release.yml already used `go-version-file: 'go.mod'`; now ci.yml does too in all four jobs, so a future patch bump is a one-line go.mod change. Current pin stays go1.26.5, which is the latest stable. The Test job's name loses its version suffix ("Test (1.26.5)" → "Test") — no ruleset requires the old name.