### PR TITLE
Dispatch the website's release-sync loop when a release publishes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,3 +136,31 @@ jobs:
           # Verify binary executes and shows usage
           $output = & ".\${{ matrix.binary }}" -h 2>&1 | Out-String
           if ($output -match "Usage") { Write-Host "Binary verified successfully" } else { exit 1 }
+
+  # Tell the website a release published. This is an explicit step with the
+  # App token because GoReleaser publishes with GITHUB_TOKEN, and events
+  # raised by GITHUB_TOKEN start no workflows — an `on: release` trigger in
+  # the website repo would simply never fire. The site's release-sync loop
+  # also runs a daily cron, so a failure here delays the homepage by at most
+  # a day rather than breaking it.
+  notify-website:
+    runs-on: ubuntu-latest
+    needs: verify
+    timeout-minutes: 5
+    steps:
+      - name: Mint GitHub App token for the website repo
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.AIXGO_GH_APP_CLIENT_ID }}
+          private-key: ${{ secrets.AIXGO_GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: web
+          permission-contents: write
+
+      - name: Dispatch release-sync
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh api "repos/${{ github.repository_owner }}/web/dispatches" \
+            -f event_type=aixgo-release-published


### PR DESCRIPTION
Companion to aixgo-dev/web's release-sync loop (the self-maintaining homepage release fact). A `notify-website` job after `verify` mints an App token scoped to the web repo and sends `repository_dispatch: aixgo-release-published`.

Why not `on: release` in the web repo: GoReleaser publishes with `GITHUB_TOKEN`, and events raised by `GITHUB_TOKEN` never start workflows — the trigger would be dead on arrival. The explicit dispatch with an App token is the reliable path, and the web repo's daily cron backstops it, so a failure in this job costs at most a day of homepage staleness.

Needs (one-time, before this can run): `AIXGO_GH_APP_CLIENT_ID` variable + `AIXGO_GH_APP_PRIVATE_KEY` secret on this repo, and the aixgo-code App installation extended to cover the `web` repo.