### PR TITLE
Add a security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,28 @@
+# Security policy
+
+## Reporting a vulnerability
+
+Report security issues privately. Go to the **Security** tab of this repository and choose **Report a vulnerability**. That opens a private advisory only the maintainers can see. Do not open a public issue for a suspected vulnerability.
+
+We aim to acknowledge a report within 3 business days.
+
+## Supported versions
+
+aixgo is pre-1.0 and the API still moves. Security fixes land on the default branch and ship in the next tagged release. Older tags are not patched, so run a recent release.
+
+## In scope
+
+aixgo is a library and a binary you run in your own infrastructure. It reads provider credentials from your environment, calls the LLM providers named in your config, and can do whatever the tools you wire up can do. Within that, we treat the following as vulnerabilities:
+
+- Bypasses of the controls in `pkg/security`: the SSRF guard, prompt injection filter, input sanitizer, rate limiter, auth and IAP checks, and log redaction.
+- Config parsing. A YAML file should not be able to make aixgo read files, open connections, or run code that the config does not describe.
+- Credential handling. Provider keys and tokens must not leak into logs, traces, audit records, or model prompts.
+- The published release artifacts and their checksums.
+
+## Out of scope
+
+- A model returning wrong, biased, or harmful text. aixgo does not vouch for provider output.
+- Prompt injection that only changes what a model says. What we act on is injected text reaching a tool, a credential, or a network destination it should not.
+- Tools you write yourself. If your tool shells out or reads arbitrary paths, that is a bug in your tool. `docs/SECURITY_BEST_PRACTICES.md` covers how to avoid it.
+- Consequences of your own deployment choices, such as exposing the HTTP surface without auth or handing an agent a key with more access than it needs.
+- Vulnerabilities in the LLM providers themselves. Report those to the provider.


### PR DESCRIPTION
The Security overview listed the security policy as disabled. Private vulnerability reporting is already on for this repository, but there was no SECURITY.md, so nobody finding a bug had a documented place to send it.

The policy points reporters at the Security tab, states a 3 business day acknowledgement, and draws the line that matters for a framework you run yourself: bypasses of `pkg/security`, config parsing that does more than the config says, credential leakage, and the release artifacts are in scope. Model output quality, tools you write yourself, and your own deployment choices are not.

## Related security work in this pass, no code change needed

The six open code scanning alerts are all the same Trivy finding, GO-2026-5932 on `golang.org/x/crypto` v0.54.0, one per module.

| Alert | Rule | File | Verdict | Action |
|---|---|---|---|---|
| 280 | GO-2026-5932 | `go.mod:1` | False positive | Dismissal requested |
| 258 | GO-2026-5932 | `examples/resilient-aggregation/go.mod:1` | False positive | Dismissal requested |
| 257 | GO-2026-5932 | `examples/pydantic-style-validation/go.mod:1` | False positive | Dismissal requested |
| 256 | GO-2026-5932 | `examples/multi-phase-workflow/go.mod:1` | False positive | Dismissal requested |
| 255 | GO-2026-5932 | `examples/deterministic-aggregation/go.mod:1` | False positive | Dismissal requested |
| 254 | GO-2026-5932 | `examples/cost-optimization/go.mod:1` | False positive | Dismissal requested |

GO-2026-5932 is not a code defect. It says `golang.org/x/crypto/openpgp` is unmaintained and should not be used. The advisory is scoped by import path to the seven `openpgp/*` packages, it is introduced at version 0, and it has no fixed version, so there is no upgrade that clears it. `go list -deps ./...` in the main module and in each example module returns zero openpgp packages, and `govulncheck` already runs over every module in CI and stays green, which is the standing reachability gate if anyone ever does import it. Trivy matched at module granularity against an import-scoped advisory.

No `.trivyignore` was added on purpose. A repository-level ignore would also hide a future real openpgp import; the per-alert dismissal does not.

Secret scanning: 0 open alerts. Dependabot: 0 open alerts.

The dismissals could not be applied directly: the organization has delegated alert dismissal turned on for code scanning, so a `PATCH` with `state=dismissed` is rejected and the API only accepts `create_request=true`. Six dismissal requests are queued as pending at `repos/aixgo-dev/aixgo/dismissal-requests/code-scanning`, requests 1 through 6, each carrying the justification above. They need an approval from a repository or organization admin before the alerts close.
